### PR TITLE
Fix incorrect "node-browserify" dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "chai": "~1.9.1",
     "istanbul": "0.1.30",
     "uglify-js": "*",
-    "node-browserify": "https://github.com/substack/node-browserify/tarball/master"
+    "browserify": "https://github.com/substack/node-browserify/tarball/master"
   },
   "testling": {
     "browsers": [


### PR DESCRIPTION
The module is just called "browserify", not "node-browserify". An `npm install` in this repo fails because of this difference, since a tarball containing a module called "browserify" is downloaded yet `npm` is expecting one containing a "node-browserify" module.

``` bash
$ npm install
npm ERR! Error: Invalid Package: expected node-browserify but found browserify
```

I guess no one has tried running `npm install` here until today: npm/npm#6202
