### PR TITLE
Fix package.json browserify dependency to enable npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "chai": "~1.9.1",
     "istanbul": "0.1.30",
     "uglify-js": "*",
-    "node-browserify": "https://github.com/substack/node-browserify/tarball/master"
+    "browserify": "https://github.com/substack/node-browserify/tarball/master"
   },
   "testling": {
     "browsers": [


### PR DESCRIPTION
Install instructions failed due to incorrect dependency.
