### PR TITLE
browser/ecdsaOps: require ethereumjs-util

### DIFF
--- a/browser/ecdsaOps.js
+++ b/browser/ecdsaOps.js
@@ -1,4 +1,4 @@
-var utils = require('../lib/utils.js'),
+var utils = require('ethereumj-utils'),
   ecdsa = require('ecdsa'),
   BigInteger = require('bigi'),
   ecurve = require('ecurve');


### PR DESCRIPTION
Was previously `require('../lib/utils.js')` and caused browserify
bundle to fail.