### PR TITLE
vm - add vm.copy

### DIFF
--- a/lib/vm/index.js
+++ b/lib/vm/index.js
@@ -11,10 +11,12 @@ const Cache = require('./cache.js');
 const JSONStream = require('JSONStream');
 const rlp = require('rlp');
 
+module.exports = VM
+
 /**
  * @constructor
  */
-var VM = module.exports = function(trie, blockchain) {
+function VM(trie, blockchain) {
   if(!trie.db){
     trie = new Trie(trie);
   }
@@ -32,6 +34,13 @@ VM.prototype.runJIT = require('./runJit.js');
 VM.prototype.runBlock = require('./runBlock.js');
 VM.prototype.runTx = require('./runTx.js');
 VM.prototype.runCall = require('./runCall.js');
+
+VM.prototype.copy = function() {
+  var trie = this.trie.copy();
+  var vm = new VM(trie, this.blockchain);
+  return vm;
+};
+
 VM.prototype.generateGenesis = function(initState, cb) {
   var self = this;
   var addresses = Object.keys(initState);


### PR DESCRIPTION
provides a method for creating a vm configured the same way as another -- useful for other vm classes (RemoteVM?) that have more complex setup/configuration