### PR TITLE
Bump secp256k1-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "merkle-patricia-tree": "^1.1.0",
     "miller-rabin": "^2.0.1",
     "rlp": "1.0.1",
-    "secp256k1": "0.0.16",
+    "secp256k1": "0.0.17",
     "semaphore": "^1.0.3",
     "sha3": "^1.1.0",
     "underscore": "^1.6.0"


### PR DESCRIPTION
this allows ethereumjs-lib to install on osx